### PR TITLE
chore(deps): include Astro 5

### DIFF
--- a/packages/astro-htmlnano/package.json
+++ b/packages/astro-htmlnano/package.json
@@ -27,7 +27,7 @@
     "@types/relateurl": "^0.2.33"
   },
   "peerDependencies": {
-    "astro": "^4"
+    "astro": ">=4"
   },
   "engines": {
     "node": ">=16.x"

--- a/packages/astro-posthtml/package.json
+++ b/packages/astro-posthtml/package.json
@@ -14,11 +14,11 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "posthtml": "^0.16.6"
+    "posthtml": "^0.16.6",
+    "shx": "^0.4.0"
   },
-  "devDependencies": {},
   "peerDependencies": {
-    "astro": "^4"
+    "astro": ">=4"
   },
   "engines": {
     "node": ">=16.x"


### PR DESCRIPTION
It was easier than I thought. It seems to build locally without any API changes that are relevant to these plugins (as posthtml/htmlnano deal with the final HTML produced by Astro, this plugin should keep working as long as there aren't breaking changes in how middlewares work in Astro).

Closes #81.